### PR TITLE
Use GUID, instead of plugin name, as key for plugin settings.

### DIFF
--- a/src/GitExtensions.GerritPlugin/GerritPlugin.cs
+++ b/src/GitExtensions.GerritPlugin/GerritPlugin.cs
@@ -52,7 +52,8 @@ namespace GitExtensions.GerritPlugin
         // public only because of FormTranslate
         public GerritPlugin() : base(true)
         {
-            SetNameAndDescription("Gerrit Code Review");
+            Id = new Guid("98AC833D-21F0-4FD7-8A0F-5616E093FC59");
+            Name = "Gerrit Code Review";
             Translate();
             Icon = Resources.IconGerrit;
         }


### PR DESCRIPTION
This change was implemented in Git Extensions with PR https://github.com/gitextensions/gitextensions/pull/8995.

This PR is to align the Plugin Manager accordingly.