### PR TITLE
Support GE 4.0.x and 4.1.x (#65)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
   <PropertyGroup>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net6.0-windows7.0</TargetFramework>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.0.4</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,19 @@
+<!-- Do not use XML namespaces here (<Project xmlns="...">), because it would break patching of version numbers during builds on AppVeyor (https://github.com/appveyor/website/pull/409) -->
+<Project>
+  <PropertyGroup>
+    <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="GitExtensions.Extensibility" Version="0.3.0.57" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2022.3.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Use the following pattern to link revision data to Gerrit:
 |--------------------|---------------------|
 | v <= 3.5.x         | v <= 1.3.2          |
 | 3.5.x < v <= 4.0.0 | 2.0.0 <= v <= 2.0.1 |
-| 4.0.1 <= v < 4.1.0 | v2.0.2              |
-| 4.1.0 <= v         | 2.0.3 <= v          |
+| 4.0.1 <= v         | 2.0.4 <= v          |
 
 ## GitExtensions Plugin Template infomration
 

--- a/UnitTests/GitExtensions.GerritPlugin.Tests/GitExtensions.GerritPlugin.Tests.csproj
+++ b/UnitTests/GitExtensions.GerritPlugin.Tests/GitExtensions.GerritPlugin.Tests.csproj
@@ -3,13 +3,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: 2.0.3.{build}
+version: 2.0.4.{build}
 
 # version suffix, if any (e.g. '-RC1', '-beta' otherwise '')
 environment:

--- a/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj
+++ b/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj
@@ -4,29 +4,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1">
+    <PackageReference Include="GitExtensions.Extensibility" />
+    <PackageReference Include="JetBrains.Annotations">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.41">
+    <PackageReference Include="Microsoft.VisualStudio.Composition">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27">
+    <PackageReference Include="Microsoft.VisualStudio.Threading">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1">
+    <PackageReference Include="Newtonsoft.Json">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.13.3">
-        <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="NUnit">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
+  <!-- References to Git Extensions' DLLs -->
   <ItemGroup>
-    <PackageReference Include="GitExtensions.Extensibility" Version="0.3.0.57" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- References to Git Extensions' DLLs -->
     <Reference Include="GitCommands">
       <HintPath>$(GitExtensionsPath)\GitCommands.dll</HintPath>
     </Reference>
@@ -45,10 +42,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
     <None Include="Resources\GerritDownload.png" />
     <None Include="Resources\GerritInstallHook.png" />
     <None Include="Resources\GerritPublish.png" />
-    <None Include="Resources\IconGerrit.png" />
+    <None Include="Resources\IconGerrit.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 
@@ -56,6 +60,10 @@
   <PropertyGroup>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageIcon>IconGerrit.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/gitextensions/GitExtensions.GerritPlugin</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj.user
+++ b/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj.user
@@ -4,10 +4,10 @@
     <!-- path is relative to $(ProjectDir) -->
     <GitExtensionsDownloadPath>..\..\..\gitextensions.shared</GitExtensionsDownloadPath>
     <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
-    <GitExtensionsReferenceVersion>latest</GitExtensionsReferenceVersion>
+    <GitExtensionsReferenceVersion>v4.0.2</GitExtensionsReferenceVersion>
     <!-- 'GitHub' or 'AppVeyor' -->
-    <GitExtensionsReferenceSource>AppVeyor</GitExtensionsReferenceSource>
+    <GitExtensionsReferenceSource>GitHub</GitExtensionsReferenceSource>
     <!-- for local builds (no download) -->
-    <GitExtensionsPath />
+    <GitExtensionsPath>$(GitExtensionsDownloadPath)</GitExtensionsPath>
   </PropertyGroup>
 </Project>

--- a/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.nuspec
+++ b/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.nuspec
@@ -11,11 +11,11 @@
     <icon>Resources\IconGerrit.png</icon>
     <dependencies>
       <group>
-        <dependency id="GitExtensions.Extensibility" version="[0.2.0, 0.4.0)" />
+        <dependency id="GitExtensions.Extensibility" version="[0.3.0, 0.4.0)" />
       </group>
       <!-- To fix Warning NU5128 Add a dependency group for net6.0-windows7.0 to the nuspec -->
       <group targetFramework="net6.0-windows7.0">
-        <dependency id="GitExtensions.Extensibility" version="[0.2.0, 0.4.0)" />
+        <dependency id="GitExtensions.Extensibility" version="[0.3.0, 0.4.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/GitExtensions.GerritPlugin/Properties/launchSettings.json
+++ b/src/GitExtensions.GerritPlugin/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "GitExtensions.GerritPlugin": {
       "commandName": "Executable",
-      "executablePath": "$(GitExtensionsExecutablePath)"
+      "executablePath": "$(GitExtensionsExecutablePath)",
+      "workingDirectory": "$(MSBuildProjectDirectory)"
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build related changes
- [x] Documentation
- [ ] Other: <!-- Please describe -->


## What is the current behavior?
Gerrit plugin seems to be not working on GE 4.0.x

Issue Number: #65


## What is the new behavior?
Not sure, maybe I'm doing something wrong or there is something wrong with my setup, but I've checked Gerrit plugin v2.0.4 on `GitExtensions-Portable-4.0.1.15887-f2567dea2`, `GitExtensions-Portable-4.0.2.16100-25100ec1f` and `GitExtensions-Portable-4.1.0.16008-d5c8b9ba7` - it seems it works fine on all of these versions.
Changed readme file, so `GE v >= 4.0.1` should use `Gerrit plugin v >= 2.0.4`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe. -->
