### PR TITLE
Fix URLs openings

### DIFF
--- a/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.cs
+++ b/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using GitUI;
 
 namespace GitExtensions.GerritPlugin
@@ -17,7 +16,7 @@ namespace GitExtensions.GerritPlugin
             var form = new FormGerritChangeSubmitted();
 
             form._NO_TRANSLATE_TargetLabel.Text = change;
-            form._NO_TRANSLATE_TargetLabel.Click += (s, e) => Process.Start(change);
+            form._NO_TRANSLATE_TargetLabel.Click += (s, e) => OsShellUtil.OpenUrlInDefaultBrowser(change);
 
             form.ShowDialog(owner);
         }

--- a/src/GitExtensions.GerritPlugin/FormGitReview.cs
+++ b/src/GitExtensions.GerritPlugin/FormGitReview.cs
@@ -176,7 +176,7 @@ defaultrebase=0");
 
         private void lnkGitReviewPatterns_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://docs.opendev.org/opendev/git-review/latest/installation.html#gitreview-file-format");
+            OsShellUtil.OpenUrlInDefaultBrowser("https://docs.opendev.org/opendev/git-review/latest/installation.html#gitreview-file-format");
         }
     }
 }

--- a/src/GitExtensions.GerritPlugin/FormPluginInformation.cs
+++ b/src/GitExtensions.GerritPlugin/FormPluginInformation.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using GitUI;
 
 namespace GitExtensions.GerritPlugin
@@ -12,19 +11,9 @@ namespace GitExtensions.GerritPlugin
             InitializeComplete();
         }
 
-        public static void ShowSubmitted(IWin32Window owner, string change)
-        {
-            var form = new FormPluginInformation();
-
-            form._NO_TRANSLATE_TargetLabel.Text = change;
-            form._NO_TRANSLATE_TargetLabel.Click += (s, e) => Process.Start(change);
-
-            form.ShowDialog(owner);
-        }
-
         private void _NO_TRANSLATE_TargetLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://docs.opendev.org/opendev/git-review/latest/installation.html#gitreview-file-format");
+            OsShellUtil.OpenUrlInDefaultBrowser("https://docs.opendev.org/opendev/git-review/latest/installation.html#gitreview-file-format");
         }
     }
 }


### PR DESCRIPTION
Following .net core migration replacing Process.Start() method to open URLs by the OsShellUtil.OpenUrlInDefaultBrowser() one

Thanks to @pmiossec for the solution

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Bug fix pretty difficult to test (don't want to open a browser) and doesn't really need documentation

## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Other:


## What is the current behavior?
Following the .net core migration we are unable to open browser links (for Gerrit documentation or on change submitted) from the Gerrit plugin

Issue Number: #62 

## What is the new behavior?

Using the OsShellUtil.OpenUrlInDefaultBrowser() that is .net core compatible to open URLs

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
