### PR TITLE
[Feature] Add a copy Gerrit change link button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Use the following pattern to link revision data to Gerrit:
 | 3.5.x < v <= 4.0.0 | 2.0.0 <= v <= 2.0.1 |
 | 4.0.1 <= v         | 2.0.5 <= v          |
 
-## GitExtensions Plugin Template infomration
+## GitExtensions Plugin Template information
 
 The [GitExtensions Plugin Template](https://github.com/gitextensions/gitextensions.plugintemplate) gives additional information about the pluign development.

--- a/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.Designer.cs
+++ b/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.Designer.cs
@@ -13,9 +13,13 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                this._NO_TRANSLATE_TargetLabel.Click -= OnChangeLinkClicked;
+                this._btnCopyIconTimer.Tick -= OnRefreshCopyButtonIcon;
+                this._btnCopyIconTimer.Dispose();
+                this.btnCopy.Click -= OnCopyToClipboardClicked;
+                components?.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -30,6 +34,7 @@
         {
             this.labelSubmitted = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_TargetLabel = new System.Windows.Forms.LinkLabel();
+            this.btnCopy = new System.Windows.Forms.Button();
             this.btnClose = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
@@ -38,7 +43,7 @@
             this.labelSubmitted.AutoSize = true;
             this.labelSubmitted.Location = new System.Drawing.Point(21, 18);
             this.labelSubmitted.Name = "labelSubmitted";
-            this.labelSubmitted.Size = new System.Drawing.Size(371, 15);
+            this.labelSubmitted.Size = new System.Drawing.Size(370, 15);
             this.labelSubmitted.TabIndex = 0;
             this.labelSubmitted.Text = "Your change has been submitted for review at the following location:";
             // 
@@ -51,6 +56,19 @@
             this._NO_TRANSLATE_TargetLabel.TabIndex = 1;
             this._NO_TRANSLATE_TargetLabel.TabStop = true;
             this._NO_TRANSLATE_TargetLabel.Text = "Location of link";
+            this._NO_TRANSLATE_TargetLabel.Click += OnChangeLinkClicked;
+            // 
+            // btnClose
+            // 
+            this.btnCopy.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCopy.Location = new System.Drawing.Point(331, 71);
+            this.btnCopy.Name = "btnCopy";
+            this.btnCopy.Size = new System.Drawing.Size(30, 26);
+            this.btnCopy.Image = GitUI.Properties.Images.CopyToClipboard;
+            this.btnCopy.ImageAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btnCopy.TabIndex = 2;
+            this.btnCopy.UseVisualStyleBackColor = true;
+            this.btnCopy.Click += OnCopyToClipboardClicked;
             // 
             // btnClose
             // 
@@ -58,8 +76,8 @@
             this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnClose.Location = new System.Drawing.Point(364, 71);
             this.btnClose.Name = "btnClose";
-            this.btnClose.Size = new System.Drawing.Size(75, 23);
-            this.btnClose.TabIndex = 2;
+            this.btnClose.Size = new System.Drawing.Size(75, 26);
+            this.btnClose.TabIndex = 3;
             this.btnClose.Text = "Close";
             this.btnClose.UseVisualStyleBackColor = true;
             // 
@@ -70,6 +88,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnClose;
             this.ClientSize = new System.Drawing.Size(462, 109);
+            this.Controls.Add(this.btnCopy);
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this._NO_TRANSLATE_TargetLabel);
             this.Controls.Add(this.labelSubmitted);
@@ -81,13 +100,13 @@
             this.Text = "Change Submitted";
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion
 
         private System.Windows.Forms.Label labelSubmitted;
         private System.Windows.Forms.LinkLabel _NO_TRANSLATE_TargetLabel;
+        private System.Windows.Forms.Button btnCopy;
         private System.Windows.Forms.Button btnClose;
     }
 }

--- a/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.cs
+++ b/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.cs
@@ -1,24 +1,65 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
+using GitCommands;
 using GitUI;
+using GitUI.Properties;
 
 namespace GitExtensions.GerritPlugin
 {
     public partial class FormGerritChangeSubmitted : GitExtensionsForm
     {
-        public FormGerritChangeSubmitted()
+        private string _changeUri;
+        private Timer _btnCopyIconTimer;
+
+        private FormGerritChangeSubmitted()
         {
             InitializeComponent();
             InitializeComplete();
         }
 
-        public static void ShowSubmitted(IWin32Window owner, string change)
+        private void Initialize(string changeUri)
         {
-            var form = new FormGerritChangeSubmitted();
+            _changeUri = changeUri;
+            _NO_TRANSLATE_TargetLabel.Text = changeUri;
 
-            form._NO_TRANSLATE_TargetLabel.Text = change;
-            form._NO_TRANSLATE_TargetLabel.Click += (s, e) => OsShellUtil.OpenUrlInDefaultBrowser(change);
+            _btnCopyIconTimer = new Timer
+            {
+                Enabled = false,
+                Interval = 3 * 1000
+            };
+            _btnCopyIconTimer.Tick += OnRefreshCopyButtonIcon;
+        }
 
+        private void OnRefreshCopyButtonIcon(object sender, EventArgs e)
+        {
+            Invoke(() => btnCopy.Image = Images.CopyToClipboard);
+        }
+
+        public static void ShowSubmitted(IWin32Window owner, string changeUri)
+        {
+            if(owner == null || string.IsNullOrEmpty(changeUri))
+            {
+                return;
+            }
+
+            using var form = new FormGerritChangeSubmitted();
+            form.Initialize(changeUri);
             form.ShowDialog(owner);
+        }
+
+        private void OnChangeLinkClicked(object sender, EventArgs e)
+        {
+            OsShellUtil.OpenUrlInDefaultBrowser(_changeUri);
+        }
+
+        private void OnCopyToClipboardClicked(object sender, EventArgs e)
+        {
+            _btnCopyIconTimer.Stop();
+
+            Clipboard.SetText(_changeUri);
+            btnCopy.Image = Images.BisectGood;
+
+            _btnCopyIconTimer.Start();
         }
     }
 }

--- a/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.cs
+++ b/src/GitExtensions.GerritPlugin/FormGerritChangeSubmitted.cs
@@ -37,7 +37,7 @@ namespace GitExtensions.GerritPlugin
 
         public static void ShowSubmitted(IWin32Window owner, string changeUri)
         {
-            if(owner == null || string.IsNullOrEmpty(changeUri))
+            if (owner == null || string.IsNullOrEmpty(changeUri))
             {
                 return;
             }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

Since this is full UI feature, it's difficult to add unitary test

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?

In most case I want to send the gerrit change link to reviewers over my favourite communication tools and currently I need to click on the link to open it in my browser, then copy the URI to finally send it to reviewers

Issue Number: N/A

## What is the new behavior?

We have a new 'Copy to clipboard' button that allows us to directly copy the gerrit change link to the clipboard and then paste it where we want without need to open the browser :

![OnChangeSubmitted](https://github.com/gitextensions/GitExtensions.GerritPlugin/assets/1344134/f5d4682c-6d24-47d0-a710-2da72597eaed)

![OnChangeUriCopied](https://github.com/gitextensions/GitExtensions.GerritPlugin/assets/1344134/a48cf465-ade6-4d1c-b03e-c66bb621939e)

## Does this PR introduce a breaking change?

- [x] No
