### PR TITLE
Add setting to disable the show change submitted dialog

### DIFF
--- a/src/GitExtensions.GerritPlugin/FormGerritPublish.cs
+++ b/src/GitExtensions.GerritPlugin/FormGerritPublish.cs
@@ -28,12 +28,16 @@ namespace GitExtensions.GerritPlugin
         private string _currentBranchRemote;
         private readonly GerritCapabilities _capabilities;
         private readonly bool _shouldTargetLocalBranch;
+        private readonly bool _showChangeSubmittedDialog;
 
-        public FormGerritPublish(IGitUICommands uiCommand, GerritCapabilities capabilities, bool shouldTargetLocalBranch)
+        public FormGerritPublish(IGitUICommands uiCommand, GerritCapabilities capabilities,
+            bool shouldTargetLocalBranch, bool showChangeSubmittedDialog)
             : base(uiCommand)
         {
             _capabilities = capabilities;
             _shouldTargetLocalBranch = shouldTargetLocalBranch;
+            _showChangeSubmittedDialog = showChangeSubmittedDialog;
+
             InitializeComponent();
             Publish.Image = Images.Push.AdaptLightness();
             InitializeComplete();
@@ -104,7 +108,7 @@ namespace GitExtensions.GerritPlugin
 
             if (!pushCommand.ErrorOccurred)
             {
-                if(GerritUtil.HadNewChange(pushCommand.CommandOutput, out var changeUri))
+                if (_showChangeSubmittedDialog && GerritUtil.HadNewChange(pushCommand.CommandOutput, out var changeUri))
                 {
                     FormGerritChangeSubmitted.ShowSubmitted(owner, changeUri);
                 }

--- a/src/GitExtensions.GerritPlugin/GerritPlugin.cs
+++ b/src/GitExtensions.GerritPlugin/GerritPlugin.cs
@@ -36,6 +36,8 @@ namespace GitExtensions.GerritPlugin
         private const string DefaultPublishTargetBranch = "local";
 
         private readonly BoolSetting _gerritEnabled = new("Gerrit plugin enabled", true);
+        private readonly BoolSetting _gerritShowChangeSubmittedDialog = new("Show change submitted dialog", false);
+
         private readonly ChoiceSetting _predefinedGerritVersion = new(
             "Treat Gerrit as having version",
             new[] { DefaultGerritVersion, "Older then 2.15" },
@@ -307,8 +309,9 @@ namespace GitExtensions.GerritPlugin
                 ? GerritCapabilities.Version2_15
                 : GerritCapabilities.OldestVersion;
             var shouldTargetLocalBranch = _predefinedPublishTargetBranch.ValueOrDefault(Settings) == DefaultPublishTargetBranch;
+            var showChangeSubmittedDialog = _gerritShowChangeSubmittedDialog.ValueOrDefault(Settings);
 
-            using (var form = new FormGerritPublish(_gitUiCommands, capabilities, shouldTargetLocalBranch))
+            using (var form = new FormGerritPublish(_gitUiCommands, capabilities, shouldTargetLocalBranch, showChangeSubmittedDialog))
             {
                 form.ShowDialog(_mainForm);
             }
@@ -479,6 +482,7 @@ namespace GitExtensions.GerritPlugin
         public override IEnumerable<ISetting> GetSettings()
         {
             yield return _gerritEnabled;
+            yield return _gerritShowChangeSubmittedDialog;
             yield return _predefinedGerritVersion;
             yield return _hidePushButton;
             yield return _predefinedPublishTargetBranch;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Other: <!-- Please describe -->


## What is the current behavior?
The change [#75](https://github.com/gitextensions/GitExtensions.GerritPlugin/pull/75) introduced a new window after publishing to Gerrit. This windows contains a copy link.

Issue Number: N/A


## What is the new behavior?
When you have an automated system that sends emails on new submissions this feature won't be useful, with the added setting you can disable this window from showing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
