### PR TITLE
fix: v3.1.1 nuget upload key

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
   <PropertyGroup>
     <UseWindowsForms>true</UseWindowsForms>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: 3.1.0.{build}
+version: 3.1.1.{build}
 
 # version suffix, if any (e.g. '-RC1', '-beta' otherwise '')
 environment:
@@ -59,7 +59,7 @@ deploy:
   name: production
   artifact: /GitExtensions.GerritPlugin.*\.nupkg/
   api_key:
-    secure: 2apdS3bqaEv20ai12PU9uXaF6w/INNVLyvFV7EdGyK8Uxdwk6KAKDuJySbmi/4uO
+    secure: IlLI/MbhdzmXF/WB2G84zYsDWePXJqHBWDb1zBPxxXvGgx0WRxzMZxuBsvCOcZvbPTRF+UcGp0d5/HT8xZUEjA==
   skip_symbols: false
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
update the uploadkey (using the one from pluginmanager).
Cannot test until merged. How is the key generated normally?

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build related changes
- [ ] Documentation
- [ ] Other: <!-- Please describe -->


## What is the current behavior?

3.1 for GE 6 is not uploaded

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe. -->


## Other information
