### PR TITLE
fix: tie plugin with gitextensions versions (not latest)

### DIFF
--- a/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj.user
+++ b/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj.user
@@ -4,9 +4,9 @@
     <!-- path is relative to $(ProjectDir) -->
     <GitExtensionsDownloadPath>..\..\..\gitextensions.shared</GitExtensionsDownloadPath>
     <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
-    <GitExtensionsReferenceVersion>latest</GitExtensionsReferenceVersion>
+    <GitExtensionsReferenceVersion>v6.0.3</GitExtensionsReferenceVersion>
     <!-- 'GitHub' or 'AppVeyor' -->
-    <GitExtensionsReferenceSource>AppVeyor</GitExtensionsReferenceSource>
+    <GitExtensionsReferenceSource>GitHub</GitExtensionsReferenceSource>
     <!-- for local builds (no download) -->
     <GitExtensionsPath>$(GitExtensionsDownloadPath)</GitExtensionsPath>
   </PropertyGroup>


### PR DESCRIPTION
close #93

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build related changes
- [ ] Documentation
- [ ] Other: <!-- Please describe -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Latest GitExtensions used for building Gerrit plugin.

Issue Number: #93


## What is the new behavior?
Use GitHub version for GitExtensions build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe. -->


## Other information
