### PR TITLE
Replace Newtonsoft.Json package with .NET10 System.Text.Json package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.13.61" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />

--- a/src/GitExtensions.GerritPlugin/FormGerritDownload.cs
+++ b/src/GitExtensions.GerritPlugin/FormGerritDownload.cs
@@ -10,7 +10,7 @@ using GitExtensions.Extensibility.Git;
 using GitExtUtils.GitUI;
 using GitUI;
 using GitUIPluginInterfaces;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using ResourceManager;
 
 namespace GitExtensions.GerritPlugin
@@ -88,30 +88,30 @@ namespace GitExtensions.GerritPlugin
             // The user can enter both the Change-Id or the number. Here we
             // force the number to get prettier branches.
 
-            JObject patchSetInfo = patchSet == null
-                ? (JObject)reviewInfo["currentPatchSet"]
-                : (JObject)((JArray)reviewInfo["patchSets"]).FirstOrDefault(q => (int)q["number"] == patchSet);
+            JsonObject patchSetInfo = patchSet == null
+                ? (JsonObject)reviewInfo["currentPatchSet"]
+                : (JsonObject)((JsonArray)reviewInfo["patchSets"]).FirstOrDefault(q => (int)q["number"] == patchSet);
             if (patchSetInfo == null)
             {
                 MessageBox.Show(owner, _cannotGetPatchSetDetails.Text, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
-            change = (string)reviewInfo["number"];
+            change = reviewInfo["number"].ToString();
             string topic = _NO_TRANSLATE_TopicBranch.Text.Trim();
 
             if (string.IsNullOrEmpty(topic))
             {
-                var topicNode = (JValue)reviewInfo["topic"];
+                var topicNode = (JsonValue)reviewInfo["topic"];
                 topic = topicNode == null
-                    ? change + "/" + (string)patchSetInfo["number"]
-                    : (string)topicNode.Value;
+                    ? change + "/" + patchSetInfo["number"].ToString()
+                    : topicNode.ToString();
             }
 
-            var authorValue = (string)((JValue)reviewInfo["owner"]["name"]).Value;
+            var authorValue = reviewInfo["owner"]["name"].ToString();
             string author = Regex.Replace(authorValue.ToLowerInvariant(), "\\W+", "_");
             string branchName = "review/" + author + "/" + topic;
-            var refSpec = (string)((JValue)patchSetInfo["ref"]).Value;
+            var refSpec = ((JsonValue)patchSetInfo["ref"]).ToString();
 
             var fetchCommand = UiCommands.CreateRemoteCommand();
 
@@ -124,7 +124,7 @@ namespace GitExtensions.GerritPlugin
 
             var checkoutCommand = UiCommands.CreateRemoteCommand();
 
-            checkoutCommand.CommandText = Commands.Branch(branchName, "FETCH_HEAD", true);
+            checkoutCommand.CommandText = Commands.Branch(branchName, Module.RevParse("FETCH_HEAD"), true);
             checkoutCommand.Completed += (_, e) =>
             {
                 if (e.IsError && e.Command.CommandText != null && e.Command.CommandText.Contains("already exists"))
@@ -183,7 +183,7 @@ namespace GitExtensions.GerritPlugin
             return path.ToPosixPath();
         }
 
-        private async Task<JObject> LoadReviewInfoAsync(int? patchSet = null)
+        private async Task<JsonObject> LoadReviewInfoAsync(int? patchSet = null)
         {
             var fetchUrl = GerritUtil.GetFetchUrl(Module, _currentBranchRemote);
 
@@ -208,7 +208,7 @@ namespace GitExtensions.GerritPlugin
             {
                 try
                 {
-                    return JObject.Parse(line);
+                    return JsonNode.Parse(line)?.AsObject();
                 }
                 catch
                 {

--- a/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj
+++ b/src/GitExtensions.GerritPlugin/GitExtensions.GerritPlugin.csproj
@@ -13,9 +13,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading">
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
-    </PackageReference>
     <PackageReference Include="NUnit">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Other: <!-- Please describe -->


## What is the current behavior?
GitExtensions moved to .NET10 internal Json implementation and got rid of third party Newtonsoft.Json dependency.
However, GerritPlugin has still the dependency and crashes (dll not found) as soon as a patch set is downloaded for example.

Issue Number: N/A


## What is the new behavior?
The change replaces Newtonsoft.Json package with .NET10 System.Text.Json package.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
